### PR TITLE
Removed align property as it's just passed through.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1379,7 +1379,6 @@ class DashboardScreen extends React.Component {
     return (
       <Grid container
         className="draggable"
-        align="center"
         justify="center"
         direction="column"
         style={{ height: 'calc(100vh - 95px)' }}
@@ -1688,7 +1687,6 @@ class ReportScreen extends React.Component {
         <Grid 
           container
           className="report-header"
-          align="center"
           justify="flex-start"
           direction="row"
           style={{
@@ -1730,7 +1728,6 @@ class ReportScreen extends React.Component {
             <Paper className="report-total paper-box" style={{ padding: 16 }}>
               <Grid
                 container
-                align="center"
                 justify="space-between"
                 direction="row"
               >
@@ -2048,7 +2045,6 @@ class LoginScreen extends React.Component {
     return (
       <Grid container
         className="draggable"
-        align="center"
         justify="center"
         direction="column"
         style={{ height: '100vh' }}
@@ -2129,7 +2125,6 @@ class LoadingScreen extends React.Component {
     return (
       <Grid 
         container
-        align="center"
         justify="center"
         direction="row"
         spacing={0} 


### PR DESCRIPTION
There is no `align` property on the upstream `material-ui` library.

https://material-ui-next.com/api/grid/

This PR removes this property as it was throwing console errors and providing no value to the project.

