### PR TITLE
Name new reports by Default to day of creation

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -914,9 +914,13 @@ class ReportBuilder {
   }
 }
 
+
 ReportBuilder.defaultSettingsObject = function () {
+  
+  let tempName = new Date().toISOString().slice(0,10);
+  
   return {
-    name: null,
+    name: tempName,
     league: null,
     autoRefresh: false,
     autoRefreshInterval: 1000 * 60 * 60, // 1 hour


### PR DESCRIPTION
When adding a new report, fill in the name with the current date. [YYYY-MM-DD]