### PR TITLE
Calculate the worth of items in a characters inventory

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -735,9 +735,11 @@ class ReportBuilder {
             let inventoryTabs = [];
             response.data.forEach(element => {
               if (element.league === report.settings.league) {
-                let tab = JSON.parse(
-                  '{"n":"MUNZ (Remove-only)","i":0,"id":"xxx","type":"InventoryStash","hidden":false}'
-                );
+                let tab = {}
+		tab.id = 0
+		tab.id = "inventory"
+	        tab.type = "InventoryStash"
+		tab.hidden = false
                 tab.n = `${element.name}-inventory`;
                 tab.characterName = element.name;
                 tab.account = report.account;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -736,10 +736,10 @@ class ReportBuilder {
             response.data.forEach(element => {
               if (element.league === report.settings.league) {
                 let tab = {}
-		tab.id = 0
-		tab.id = "inventory"
-	        tab.type = "InventoryStash"
-		tab.hidden = false
+                tab.id = 0
+                tab.id = "inventory"
+                tab.type = "InventoryStash"
+                tab.hidden = false
                 tab.n = `${element.name}-inventory`;
                 tab.characterName = element.name;
                 tab.account = report.account;

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ module.exports = {
   POE_MY_ACCOUNT_URL: 'https://www.pathofexile.com/my-account',
   POE_GET_CHARACTERS_URL: 'https://www.pathofexile.com/character-window/get-characters',
   POE_STASH_ITEMS_URL: `https://www.pathofexile.com/character-window/get-stash-items`,
+  POE_INVENTORY_ITEMS_URL: `https://www.pathofexile.com/character-window/get-items`,
 
   POE_COOKIE_NAME: 'POESESSID',
   POE_COOKIE_REGEXP: /^[0-9A-Fa-f]{32}$/,


### PR DESCRIPTION
## Changes
- add the search for character inventory-tabs
- inventory-tabs are shown in the fetched tabs list (only the characters in the selected league)
- worth of the inventory is calculated (with the normal fetchTab function)

## Testing
- create new report 
- select newly found {characterName}-inventory tabs (and some normal tabs)
- create the report and make sure the worth is also calculated for those new tabs

## Discussion
- should there be a setting to specify if we want to include the inventory tabs in the report?
- should the inventory tab names be different or have a different color