### PR TITLE
Determine variants for maps, fuzzy matching for gems

### DIFF
--- a/src/classes/item.js
+++ b/src/classes/item.js
@@ -36,12 +36,33 @@ class Item {
       .replace('Superior ', ''))
   }
 
+  // Determine the 'variant' of items, e.g. some special propery that differentiates
+  // items with multiple versions with otherwise identical names
+  // the variant (if we know it) must match with the poe.ninja item variant.
   get variant () {
     if (this._variant != undefined) {
       return this._variant
     }
 
-    let {explicitMods} = this.source
+    const {explicitMods, icon, category} = this.source
+    if (category && 'maps' in category) {
+      if (this.name === 'The Beachhead') {
+        if (icon.indexOf('HarbingerRed') !== -1)
+          return this._variant = 'T15'
+        else if (icon.indexOf('HarbingerYellow') !== -1)
+          return this._variant = 'T10'
+        else if (icon.indexOf('HarbingerWhite') !== -1)
+          return this._variant = 'T5'
+      }
+
+      if (icon.indexOf('/Maps/Atlas2Maps/') !== -1) return this._variant = 'Atlas2'     // war of the atlas (notched round maps)
+      else if (icon.indexOf('/Maps/AtlasMaps/') !== -1) return this._variant = 'Atlas'  // atlas of worlds (round maps)
+      else if (icon.indexOf('/Maps/act4maps/') !== -1) return this._variant = 'Pre 2.0' // release
+      else if (icon.indexOf('/Maps/') !== -1) return this._variant = 'Pre 2.4'          // awakening (square maps) 
+
+      return this._variant = null
+    }
+
     if (explicitMods && explicitMods.length) {
       if (explicitMods.indexOf('Has 1 Abyssal Socket') > -1) {
         return this._variant = '1 Jewel'
@@ -58,14 +79,6 @@ class Item {
   get fullName () {
     if (this._fullName != undefined) {
       return this._fullName
-    }
-
-    if (this.variant && this.name) {
-      return this._fullName = `${this.variant} ${this.name} ${this.type}`
-    }
-
-    if (this.variant && this.type) {
-      return this._fullName = `${this.variant} ${this.type}`
     }
 
     if (this.name && this.type) {

--- a/src/classes/portfolio.js
+++ b/src/classes/portfolio.js
@@ -104,8 +104,9 @@ class Portfolio {
               let levelTolerance = Math.max(0, Math.ceil(5 - Math.max(item.level, v.gemLevel)*0.25));
               let qualityTolerance = Math.max(0, Math.ceil(4 - Math.max(item.quality, v.gemQuality) * 0.2));
 
-              if (item.lname === 'enhance' || item.lname === 'empower' || item.lname === 'enlighten')
+              if (item.fullName.indexOf('Enhance Support') !== -1 || item.fullName.indexOf('Empower Support') !== -1 || item.fullName.indexOf('Enlighten Support') !== -1) {
                 levelTolerance = 0;
+              }
 
               let levelsClose = Math.abs(v.gemLevel - item.level) <= levelTolerance;
               let qualityClose = Math.abs(v.gemQuality - item.quality) <= qualityTolerance;

--- a/src/classes/portfolio.js
+++ b/src/classes/portfolio.js
@@ -104,6 +104,9 @@ class Portfolio {
               let levelTolerance = Math.max(0, Math.ceil(5 - Math.max(item.level, v.gemLevel)*0.25));
               let qualityTolerance = Math.max(0, Math.ceil(4 - Math.max(item.quality, v.gemQuality) * 0.2));
 
+              if (item.lname === 'enhance' || item.lname === 'empower' || item.lname === 'enlighten')
+                levelTolerance = 0;
+
               let levelsClose = Math.abs(v.gemLevel - item.level) <= levelTolerance;
               let qualityClose = Math.abs(v.gemQuality - item.quality) <= qualityTolerance;
 

--- a/src/classes/portfolio.js
+++ b/src/classes/portfolio.js
@@ -86,10 +86,9 @@ class Portfolio {
         item = Item.toItem(item)
   
         let price = prices.find(v => {
-          let match = v.fullName === item.fullName
-          if (match) {
+          if (v.fullName === item.fullName) {
             // Low Confidence Filter
-            if (v.count && v.count < 1) {
+            if ('count' in v && v.count < 1) {
               return false
             }
 
@@ -101,19 +100,25 @@ class Portfolio {
             // Price check fallthroughs
             if (v.links) {
               return v.links === item.links
-            } else if (v.gemQuality && v.gemLevel) {
-              return v.gemQuality === item.quality && v.gemLevel === item.level
+            } else if (v.gemQuality || v.gemLevel) {
+              let levelTolerance = Math.max(0, Math.ceil(5 - Math.max(item.level, v.gemLevel)*0.25));
+              let qualityTolerance = Math.max(0, Math.ceil(4 - Math.max(item.quality, v.gemQuality) * 0.2));
+
+              let levelsClose = Math.abs(v.gemLevel - item.level) <= levelTolerance;
+              let qualityClose = Math.abs(v.gemQuality - item.quality) <= qualityTolerance;
+
+              return levelsClose && qualityClose;
             } else if (v.quality && v.level) {
               return v.quality === item.quality && v.level === item.level
             } else if (v.quality) {
               return v.quality === item.quality
             } else if (v.level) {
               return v.level === item.level
-            } else if (v.variant) {
+            } else if (v.variant && item.variant) { // to simplify the logic, we sometimes set a variant event if poe.ninja doesn't
               return v.variant === item.variant
+            } else {
+              return true
             }
-
-            return true
           }
 
           return false


### PR DESCRIPTION
Alright take 2.

I hope removing the variant string from item.fullName doesn't have any consequences, if the variant is in the name the items would never be matched in portfolio.js so it had to go for this to work at all.

I've also taken the liberty of improving the gem comparisons a little, in the previous state it would give false positive matches for gems where poe.ninja listed a version with either quality 0 or level 0 (the check was skipped so it defaulted to true since the name matched). 