### PR TITLE
Filtering leagues that aren't started yet (avoid data gathering errors)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -252,6 +252,7 @@ class App extends React.Component {
 
       this.setLoadingMessage('Fetching Leagues')
       let leagues = await CC.Api.getLeagues()
+      leagues = this.filterNotStartedLeagues(leagues)
       await this.setState({ leagues })
 
       // Check rate-limiting
@@ -367,6 +368,14 @@ class App extends React.Component {
    * MISC
    */
 
+  filterNotStartedLeagues (leagues) {
+    let actualDate = new Date()
+    leagues = leagues.filter(function(league){
+      return(new Date(league.startAt) <= actualDate)
+    })
+
+    return leagues
+  }
   
   doOfflineCheck () {
     if (CC.isOffline) {


### PR DESCRIPTION
Fixing https://github.com/currency-cop/currency-cop/issues/84

Basically just checking the start date of each leagues with the actual date to keep a list of active only leagues at the start of the app.