### PR TITLE
Temporarily remove Session ID validation due to /login behind Cloudflare

### DIFF
--- a/src/classes/api.js
+++ b/src/classes/api.js
@@ -13,15 +13,6 @@ class ApiClient {
   }
 
   async authorize ({ sessionId }) {
-    let sessionResponse = await Api.LoginWithCookie(sessionId)
-    if (sessionResponse.status != 302) {
-      this.log.warn(`[AUTHORIZE]: Expired Session ID - ${sessionResponse.status}`)
-      throw ({
-        code: 400,
-        message: 'Session ID failed to authorize your account. Try refreshing your session id.'
-      })
-    }
-
     let accountResponse = await Api.GetAccountName(sessionId)
     if (!accountResponse || !accountResponse.data) {
       this.log.warn(`[AUTHORIZE]: Empty response from server on name check`)


### PR DESCRIPTION
With /login now behind Cloudflare checking the Session ID is causing problems and preventing the use of the app.

As a temporary work around disable checking if the Session ID is still valid and proceed as usual until a permanent fix can be implemented.