### PR TITLE
Don't query API if 'qualifier' in league string

### DIFF
--- a/src/classes/api.js
+++ b/src/classes/api.js
@@ -70,7 +70,13 @@ class ApiClient {
     let isEvent = league.indexOf(' Event') > -1
     let isSSF = league.indexOf('SSF ') > -1
     let isHC = league.match(/\s?HC\s?/)
+    let isQualifier = league.indexOf('Qualifier') > -1
 
+    // Qualifiers are not currently supported
+    if (isQualifier) {
+      return;
+    }
+    
     // Patch for leagues like:
     // SSF Flashback Event (BRE003) -> 001 (Standard)
     // HC SSF Flashback Event (BRE004) -> 002 (Hardcore)


### PR DESCRIPTION
Fixes #113 

I haven't tested this since then but presumably still works and I would guess it won't break anything. 

Not neat or anything, but feel free to have it if you want it.