### PR TITLE
Contains check instead of equality when checking version in case of white space

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -400,7 +400,7 @@ class App extends React.Component {
     let versionCheck = await DoVersionCheck()
     if (versionCheck && versionCheck.data) {
       let latestVersion = versionCheck.data[0]
-      if (latestVersion.name !== CC.AppVersion) {
+      if (!(latestVersion.name.indexOf(CC.AppVersion) > -1)) {
         this.setState({
           upToDate: false,
           newVersion: latestVersion


### PR DESCRIPTION
A possible fix for #122 . 
Alternatively could trim the strings. Not familiar with how name gets set but I assume during release so there's always the possibility of an ooopsie daisy. Correct me if I'm wrong 😄 

